### PR TITLE
Support batching

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,8 +16,10 @@ Relatively slim wrappers classes handle the somewhat cumbersome configuration pr
 
 All basic transform types are supported for arbitrary dimensions (up to three, as supported by the underlying libraries) and sizes, for both in- and out-of-place mode.
 Buffer offsets are also supported.
+Batched transforms are supported to the same extent that each backend does.
 Currently, no wrappers exist to perform convolutions with |vkfft|_, though one may use the low-level bindings to do so exactly as with |vkfft|_ directly.
 |clfft|_ callbacks also have yet to be implemented.
+
 
 Installation
 ------------

--- a/pycl_fft/vkfft.py
+++ b/pycl_fft/vkfft.py
@@ -199,7 +199,7 @@ class Transform:
         self.config.FFTdim = len(shape)
         self.config.size = shape[::-1]
         if axes is not None:
-            omit_dims = [int(i in axes) for i in range(len(shape))][::-1]
+            omit_dims = [int(i not in axes) for i in range(len(shape))][::-1]
             self.config.omitDimension = omit_dims
 
         self.config.specifyOffsetsAtLaunch = True


### PR DESCRIPTION
Closes #2.

@isuruf, IIUC your use case should be covered by passing `axes=(1,)` - sound right?